### PR TITLE
Add docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,5 @@ RUN \
 WORKDIR /app
 EXPOSE 3000
 CMD [ "npm", "run", "installandstartdev" ]
+
+HEALTHCHECK CMD curl -f http://localhost:3000/health || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       - 3000:3000
     volumes:
       - .:/app
-    restart: always
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       - 3000:3000
     volumes:
       - .:/app
+    restart: always

--- a/src/server.js
+++ b/src/server.js
@@ -22,6 +22,8 @@ app.use((req, res, next) => {
   next();
 });
 
+app.get("/health", (req, res) => res.sendStatus(200));
+
 const handler = (res, params) => {
   osmsm(params)
     .then(data => res.end(data))


### PR DESCRIPTION
Hey there,

I had a problem recently: the container stopped working because of a nasty error `pthread_create: Resource temporarily unavailable`.
It stopped working but was always "healthy" from the docker point of view.

This PR adds a `HEALTHCHECK` in the Dockerfile so that docker can detect if the service is down and restart the container if needed.

I created a special endpoint `/health` for that, to avoid wasting resources by generating an image on `/`.