### PR TITLE
fix: escape special characters before insertion to template

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -19,6 +19,23 @@ app.use((req, res, next) => {
   next();
 });
 
+
+function htmlEscape(text) {
+  return text.replace(/&/g, '&amp;').
+  replace(/</g, '&lt;').
+  replace(/"/g, '&quot;').
+  replace(/'/g, '&#039;');
+}
+
+
+function sanitize(params) {
+  result = {}
+  for (let [key, value] of Object.entries(params)) {
+      result[key] = htmlEscape(value)
+  }
+  return result;
+}
+
 app.get("/health", (req, res) => res.sendStatus(200));
 
 const handler = (res, params) => {
@@ -30,12 +47,14 @@ const handler = (res, params) => {
 app.get("/", (req, res) => handler(res, req.query));
 app.post("/", (req, res) => handler(res, req.body));
 
-app.get("/dynamic", (req, res) =>
-  handler(res, { ...req.query, renderToHtml: true })
-);
+app.get("/dynamic", (req, res) => {
+  var sanitized = sanitize(req.query)
+  handler(res, { ...sanitized, renderToHtml: true })
+})
 
-app.post("/dynamic", (req, res) =>
-  handler(res, { ...req.body, renderToHtml: true })
-);
+app.post("/dynamic", (req, res) => {
+  var sanitized = sanitize(req.body)
+  handler(res, { ...sanitized, renderToHtml: true })
+})
 
 module.exports = http.createServer(app);


### PR DESCRIPTION
For the sample server, this PR sanitizers characters such as quotes and double quotes to prevent XSS payloads. E.g. `'+alert(1)+'`  