### PR TITLE
Add an option to CLI to read GeoJSON file or STDIN

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,7 @@ program
     "[options]\nGenerate an image of a geojson with a background map layer"
   )
   .option("-g, --geojson <string>", "Geojson object to be rendered")
+  .option("-f, --geojsonfile <string>", "Geojson file name to be rendered (\"-\" reads STDIN)")
   .option(
     "-H, --height <number>",
     "Height in pixels of the returned img",
@@ -138,6 +139,12 @@ program.on("--help", function() {
   );
   process.stdout.write(
     `  $ osmsm -g '[{"type":"Feature","properties":{"party":"Republican"},"geometry":{"type":"Polygon","coordinates":[[[-104.05,48.99],[-97.22,48.98],[-96.58,45.94],[-104.03,45.94],[-104.05,48.99]]]}},{"type":"Feature","properties":{"party":"Democrat"},"geometry":{"type":"Polygon","coordinates":[[[-109.05,41.00],[-102.06,40.99],[-102.03,36.99],[-109.04,36.99],[-109.05,41.00]]]}}]' --height=300 --width=300\n`
+  );
+  process.stdout.write(
+    `  $ osmsm -f /path/to/my_file.json\n`
+  );
+  process.stdout.write(
+    `  $ program_with_geojson_on_stdout | osmsm -f -\n`
   );
   process.stdout.write("\n");
 });

--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -10,6 +10,12 @@ interface OsmStaticMapsOptions {
   geojson?: string | GeoJSON.GeoJSON;
 
   /**
+   * Geojson file name to be rendered in the map
+   * @defaultValue `undefined`
+   */
+  geojsonfile?: string;
+
+  /**
    * height in pixels of the returned img
    * @defaultValue `600`
    */

--- a/src/lib.js
+++ b/src/lib.js
@@ -56,6 +56,7 @@ module.exports = function(options) {
   return new Promise(function(resolve, reject) {
     options = options || {};
     options.geojson = (options.geojson && (typeof options.geojson === 'string' ? options.geojson : JSON.stringify(options.geojson))) || '';
+    options.geojsonfile = options.geojsonfile || '';
     options.height = options.height || 600;
     options.width = options.width || 800;
     options.center = options.center || '';
@@ -72,6 +73,10 @@ module.exports = function(options) {
     options.markerIconOptions = (options.markerIconOptions && (typeof options.markerIconOptions === 'string' ? options.markerIconOptions : JSON.stringify(options.markerIconOptions))) || false;
     options.style = (options.style && (typeof options.style === 'string' ? options.style : JSON.stringify(options.style))) || false;
     options.timeout = typeof options.timeout == undefined ? 20000 : options.timeout
+
+    if (options.geojsonfile) {
+      options.geojson= fs.readFileSync(options.geojsonfile=="-"?process.stdin.fd:options.geojsonfile, 'utf8');
+    }
 
     const html = replacefiles(template(options));
 


### PR DESCRIPTION
Add a new "-f" or "--geojsonfile" option to read GeoJSON data from an
input file instead of command line, thus allowing to render a map with
a big data set (like a long GPS track), solving this error:
/usr/local/bin/osmsm: Argument list too long

To read from STDIN, use "-" as file name.

Feature request described in issue #23 