### PR TITLE
Add popup option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ All parameters have a short and long version. The short version can be used only
 | k | markerIconOptions | set marker icon options ([a json options object](https://leafletjs.com/reference-1.6.0.html#icon-option)) *see note | `undefined` (leaflet's default marker) |
 | S | style | style to apply to each feature ([a json options object](https://leafletjs.com/reference-1.6.0.html#path-option)) *see note | `undefined` (leaflet's default) |
 | e | haltOnConsoleError | throw error if there is any `console.error(...)` when rendering the map image | `false` |
+| P | popup | render opened popup instead of marker icon for single point map | `undefined` |
+
 
 * Note on markerIconOptions: it's also accepted a markerIconOptions attribute in the geojson feature, for example `{"type":"Point","coordinates":[-105.01621,39.57422],"markerIconOptions":{"iconUrl":"https://leafletjs.com/examples/custom-icons/leaf-red.png"}}`
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -99,6 +99,10 @@ program
     "throw error if there is any console.error(...) when rendering the map image",
     false
   )
+  .option(
+    "-P, --popup <string>", 
+    "HTML or text content of popup"
+  )  
   .action(function(cmd) {
     const opts = cmd.opts();
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -2,6 +2,24 @@ const fs = require('fs');
 const http = require('http');
 const https = require("https");
 const Handlebars = require('handlebars');
+
+Handlebars.registerHelper('isOnePoint', function(jsonString, options) {
+  let obj;
+  try {
+    obj = JSON.parse(jsonString);
+  } catch (e) {
+    console.error('Error parsing JSON:', e);
+    return options.inverse(this); // Handle parse error or incorrect format
+  }
+  
+  // Check if the object is indeed an object, not an array, and has the required keys
+  if (typeof obj === 'object' && obj !== null && !Array.isArray(obj) && obj.type === "Point" && obj.coordinates) {
+    return options.fn(this); // Execute the block if condition is met
+  }
+  
+  return options.inverse(this); // Execute the else block if conditions are not met
+});
+
 const path = require('path');
 const child_process = require("child_process");
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -48,7 +48,7 @@ class Browser {
       args: [...chrome.args, "--no-sandbox", "--disable-setuid-sandbox"],
       defaultViewport: chrome.defaultViewport,
       executablePath: await chrome.executablePath,
-      headless: true,
+      headless: new,
       ignoreHTTPSErrors: true,
     });
   }

--- a/src/template.html
+++ b/src/template.html
@@ -20,6 +20,12 @@
             height: 100%;
             width: 100%;
         }
+{{#if popup}} {{#isOnePoint geojson}}        
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+	display: none;
+	}        
+{{/isOnePoint}}  {{/if}}            
         </style>
         <script>
         //leafletjs//

--- a/src/template.html
+++ b/src/template.html
@@ -6,6 +6,9 @@
         .leaflet-fade-anim, .leaflet-zoom-anim {
             transition: none;
         }
+        .leaflet-popup-close-button {
+            display: none;
+        }            
         body {
             height: 100%;
             width: 100%;

--- a/src/template.html
+++ b/src/template.html
@@ -110,6 +110,11 @@
                     },
                 });
                 geojsonlayer.addTo(map);
+                {{#if popup}}
+                    {{#isOnePoint geojson}}
+                        geojsonlayer.bindPopup('{{{ popup }}}').openPopup();
+                    {{/isOnePoint}}                
+                {{/if}}                         
                 map.fitBounds(geojsonlayer.getBounds(), {maxZoom: maxZoom});
             {{/if}}
 


### PR DESCRIPTION
This PR adds a popup option for maps showing a single point. Instead of a marker icon, an open popup is rendered containing HTML or text.

![map_with_popup](https://github.com/jperelli/osm-static-maps/assets/4996484/c5902e57-d3bb-4be0-8df8-9df4415bbb6a)
