### PR TITLE
Fix center off when using geojson

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -123,21 +123,21 @@
                 map.fitBounds(geojsonlayer.getBounds(), {maxZoom: maxZoom});
             {{/if}}
 
-            {{#if center}}
-                map.panTo(L.latLng('{{ center }}'.split(',')[1], '{{ center }}'.split(',')[0]), {animate: false});
-            {{else}}
-                {{#if geojson}}
-                {{else}}
-                    map.panTo(initialPoint, {animate: false});
-                {{/if}}
-            {{/if}}
-
             {{#if zoom}}
                 map.setZoom({{ zoom }}, {animate: false});
             {{else}}
                 {{#if geojson }}
                 {{else}}
                     map.setZoom(maxZoom, {animate: false})
+                {{/if}}
+            {{/if}}
+
+            {{#if center}}
+                map.panTo(L.latLng('{{ center }}'.split(',')[1], '{{ center }}'.split(',')[0]), {animate: false});
+            {{else}}
+                {{#if geojson}}
+                {{else}}
+                    map.panTo(initialPoint, {animate: false});
                 {{/if}}
             {{/if}}
 

--- a/src/template.html
+++ b/src/template.html
@@ -63,6 +63,7 @@
             {{/if}}
 
             var maxZoom = Number({{maxZoom}});
+            var maxNativeZoom = Math.min(Number({{maxNativeZoom}}) || maxZoom, maxZoom);
             var initialPoint = L.latLng(-34.921779, -57.9524339);
 
             var map = new L.Map('map', {
@@ -156,6 +157,7 @@
                         '{{{tileserverUrl}}}',
                         {
                             maxZoom: maxZoom,
+                            maxNativeZoom: maxNativeZoom,
                             fadeAnimation: false
                         }
                     );


### PR DESCRIPTION
When using geojson, first the map is panned to the provided center, and then it's zoomed in to the desired level.
Because of rounding errors, the center will be off.

By changing the order of operations (first zoom, then pan), the issue is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved map behavior by adjusting the order of zoom and center settings, ensuring smoother and more intuitive map view updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->