### PR TITLE
Allow passing maxNativeZoom

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -63,6 +63,7 @@
             {{/if}}
 
             var maxZoom = Number({{maxZoom}});
+            var maxNativeZoom = Math.min(Number({{maxNativeZoom}}) || maxZoom, maxZoom);
             var initialPoint = L.latLng(-34.921779, -57.9524339);
 
             var map = new L.Map('map', {
@@ -156,6 +157,7 @@
                         '{{{tileserverUrl}}}',
                         {
                             maxZoom: maxZoom,
+                            maxNativeZoom: maxNativeZoom,
                             fadeAnimation: false
                         }
                     );


### PR DESCRIPTION
maxNativeZoom makes it possible to zoom beyond max zoom level of the tile provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a maximum native zoom level for tile layers, ensuring it does not exceed the maximum zoom setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->